### PR TITLE
mip-img

### DIFF
--- a/src/components/mip-img.js
+++ b/src/components/mip-img.js
@@ -120,6 +120,9 @@ define(function (require) {
     };
 
     function firstInviewCallback() {
+        if(this.element.querySelector('img')&&this.element.querySelector('img').length > 0 ){
+            return;
+        }
         var _img = new Image();
         this.applyFillContent(_img, true);
         var ele = this.element;

--- a/src/components/mip-img.js
+++ b/src/components/mip-img.js
@@ -120,7 +120,8 @@ define(function (require) {
     };
 
     function firstInviewCallback() {
-        if(this.element.querySelector('img') && this.element.querySelector('img').length > 0 ){
+        var ele = this.element.querySelector('img');
+        if(ele && ele.length > 0){
             return;
         }
         var _img = new Image();

--- a/src/components/mip-img.js
+++ b/src/components/mip-img.js
@@ -120,7 +120,7 @@ define(function (require) {
     };
 
     function firstInviewCallback() {
-        if(this.element.querySelector('img')&&this.element.querySelector('img').length > 0 ){
+        if(this.element.querySelector('img') && this.element.querySelector('img').length > 0 ){
             return;
         }
         var _img = new Image();


### PR DESCRIPTION
mip-img组件在和mip-fixed组件 以及mip-semi-fixed组件 进行嵌套时会被初始化两次，导致在页面中出现两个img标签。
存在问题的示例页面：https://gkrace.github.io/test_component/mip-semi-fixed.html
存在问题的示例SF页面：https://www.mipengine.org/validator/preview/s?url=https%3A%2F%2Fgkrace.github.io%2Ftest_component%2Fmip-semi-fixed.html
错误情况是，页面中会出现两个img


【组件测试】
我们提供两个组件的页面为修改版
1.mip-semi-fixed ：https://gkrace.github.io/test_component/index.html
SF页面：https://www.mipengine.org/validator/preview/s?url=https://gkrace.github.io/test_component/index.html
2. mip-fixed：https://gkrace.github.io/test_component/mip-fixed.html
SF页面：https://www.mipengine.org/validator/preview/s?url=https://gkrace.github.io/test_component/mip-fixed.html
