### PR TITLE
Revert "修复async加载mip.js导致的页面在ios safari不能滑动问题 (#207)"

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -78,7 +78,6 @@ MIP（移动网页加速器)能够优化网页JS和资源加载，达到加速�
 4. 符合[Fecs](http://fecs.baidu.com/demo)编码规范
 
 ## License
-
 [MIT](https://github.com/mipengine/mip/blob/master/LICENSE)
 
 Copyright (c) 2015-present, Baidu Inc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip",
-  "version": "1.0.61",
+  "version": "1.0.60",
   "description": "mobile instant page",
   "main": "dist/mip.js",
   "dependencies": {},

--- a/src/less/mip-base.less
+++ b/src/less/mip-base.less
@@ -9,19 +9,6 @@ body {
     box-sizing: border-box;
     -webkit-box-sizing: border-box;
 }
-html, body {
-    height: 100%;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    position: relative;
-}
-html.mip-i-android-scroll,
-body.mip-i-android-scroll {
-    height: auto;
-    overflow-y: visible;
-    -webkit-overflow-scrolling: touch;
-    position: static;
-}
 a {
     text-decoration : none;
     color: #333;
@@ -151,5 +138,3 @@ imip-sizer {
     visibility: hidden;
     overflow: hidden;    
 }
-
-

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -62,20 +62,19 @@ define(function (require) {
          * Patch for iframe
          */
         patchForIframe: function () {
-            // When page in an iframe and browser is IOS,
-            // page can not be scrollable. So we need
-            // set the style to be `height: 100%; overflow: auto`
-            // to solve this problem.
-            if (!platform.needSpecialScroll) {
-                document.documentElement.classList.add('mip-i-android-scroll');
-                document.body.classList.add('mip-i-android-scroll');
+            // When page in an iframe and browser is IOS, page can not be scrollable. So we need
+            // set the style to be `height: 100%; overflow: auto` for solving this problem.
+            if (platform.needSpecialScroll) {
+                css([document.documentElement, document.body], {
+                    'height': '100%',
+                    'overflow-y': 'auto',
+                    '-webkit-overflow-scrolling': 'touch'
+                });
+                css(document.body, 'position', 'relative');
             }
 
-            // Fix iphone 5s UC and ios 9 safari bug.
-            // While the back button is clicked,
-            // the cached page has some problems.
-            // So we are forced to load the page in iphone 5s UC
-            // and iOS 9 safari.
+            // Fix iphone 5s UC and ios 9 safari bug. While the back button is clicked, the cached page has some problems.
+            // So we are forced to load the page in iphone 5s UC and ios 9 safari.
             var iosVersion = platform.getOsVersion();
             iosVersion = iosVersion ? iosVersion.split('.')[0] : '';
             var needBackReload = (iosVersion == '8' && platform.isUc() && screen.width === 320)

--- a/test/viewer.js
+++ b/test/viewer.js
@@ -24,22 +24,19 @@ define(function (require) {
 
     describe('viewer', function () {
         it('patchForIframe', function () {
-            document.body.classList.remove('mip-i-android-scroll');
-            util.platform.needSpecialScroll = true;
+            util.platform.needSpecialScroll = false;
             document.body.style.cssText = '';
             document.body.style.margin = 0;
-            function normalScroll() {
-                var hasClass = document.body.className.match('mip-i-android-scroll');
-                return !!hasClass;
+            function checkHeight() {
+                return document.body.style.height === '100%';
             };
             viewer.patchForIframe();
-            var needSpecialhasNormalClass = normalScroll();
-
-            util.platform.needSpecialScroll = false;
+            var initedHeightEmpty = !checkHeight();
+            util.platform.needSpecialScroll = true;
             viewer.patchForIframe();
 
-            expect(needSpecialhasNormalClass).to.be.false;
-            expect(normalScroll()).to.be.true;
+            expect(initedHeightEmpty).to.be.true;
+            expect(checkHeight()).to.be.true;
         });
 
         it('needBackReload', function () {


### PR DESCRIPTION
脚本依赖v1/mip.css， 但线上存量有站长使用mipmain-v0.0.1.css， 导致修改不能生效。