### PR TITLE
bugfix: bind 多个事件书写不能全部执行

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "mobile instant page",
   "main": "dist/mip.js",
   "dependencies": {},

--- a/src/utils/event-action.js
+++ b/src/utils/event-action.js
@@ -149,7 +149,8 @@ define(function (require) {
                 var action = actions[i];
                 var globalTarget = this.globalTargets[action.id];
                 if (globalTarget) {
-                    return globalTarget(action);
+                    globalTarget(action);
+                    continue;
                 }
                 var target = this.getTarget(action.id);
                 if (this.checkTarget(target)) {


### PR DESCRIPTION
通过 event-action 书写的事件，如果包含 mip-bind 事件，其后事件不会执行