### PR TITLE
feat: 优化 viewport 的 scroll, resize, changed 事件

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "mobile instant page",
   "main": "dist/mip.js",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "description": "mobile instant page",
   "main": "dist/mip.js",
   "dependencies": {},

--- a/src/resources.js
+++ b/src/resources.js
@@ -50,14 +50,11 @@ define(function (require) {
         // add to resources
         resources[this._rid] = {};
 
-        // Reduce the frequency of updating viewport state
-        var update = this._update.bind(this);
-
         /**
          * The method to udpate state.
          * @type {Function}
          */
-        this.updateState = fn.throttle(update);
+        this.updateState = this._update.bind(this);
 
         /**
          * Viewport


### PR DESCRIPTION
1. 由于 `viewport.scroll` 事件已经在使用，并且一些组件依赖该事件做一些悬浮元素处理，故该事件节流为 `1000 / 60` ，对组件影响较小
2. 由于刷新视图对 `scroll` 事件的周期要求不高（如不想滚动一次刷新100次，其实20次就够了），故使用 `changed` 事件，节流 `200` 
3. `changed` 事件文档调整，从之前的“低速滚动”触发变更为“浏览器滚动时低频率触发”

fix #267 , fix #266 