### PR TITLE
feat: 添加图片提前渲染

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mip",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "description": "mobile instant page",
   "main": "dist/mip.js",
   "dependencies": {},

--- a/src/components/mip-img.js
+++ b/src/components/mip-img.js
@@ -306,5 +306,19 @@ define(function (require) {
         return true;
     };
 
+    /**
+     * Advance one screen loading
+     *
+     * @param  {Object} offset         Element offset
+     * @param  {Object} viewportOffset Window offset
+     * @return {boolean}
+     */
+    customElem.prototype.prerenderAllowed = function (offset, viewRect) {
+        var threshold = viewRect.height;
+
+        return viewRect.top + viewRect.height + threshold >= offset.top
+            && offset.top + offset.height + threshold >= viewRect.top;
+    };
+
     return customElem;
 });

--- a/src/element.js
+++ b/src/element.js
@@ -153,8 +153,8 @@ define(function (require) {
          *
          * @return {boolean}
          */
-        proto.prerenderAllowed = function () {
-            return this.customElement.prerenderAllowed();
+        proto.prerenderAllowed = function (offset, viewport) {
+            return this.customElement.prerenderAllowed(offset, viewport);
         };
 
         /**

--- a/src/resources.js
+++ b/src/resources.js
@@ -157,8 +157,9 @@ define(function (require) {
             for (var i in resources) {
                 // Compute the viewport state of current element.
                 // If current element`s prerenderAllowed returns `true` always set the state to be `true`.
-                var inViewport = resources[i].prerenderAllowed()
-                    || rect.overlapping(rect.getElementRect(resources[i]), viewportRect);
+                var elementRect = rect.getElementRect(resources[i]);
+                var inViewport = resources[i].prerenderAllowed(elementRect, viewportRect)
+                    || rect.overlapping(elementRect, viewportRect);
                 this.setInViewport(resources[i], inViewport);
             }
         }

--- a/test/resources.js
+++ b/test/resources.js
@@ -198,8 +198,18 @@ define(function (require) {
                 sinon.stub(app, 'getResources', function () {
                     return {
                         MIP: {
-                            prerenderAllowed: function () {
+                            prerenderAllowed: function (offset, viewportRect) {
+                                expect(offset).to.be.a('object').and.not.empty;
+                                expect(viewportRect).to.be.a('object').and.not.empty;
                                 return true;
+                            },
+                            getBoundingClientRect: function () {
+                                return {
+                                    left: 0,
+                                    top: 0,
+                                    width: 0,
+                                    height: 0
+                                };
                             }
                         }
                     };


### PR DESCRIPTION
使用 `prerenderAllowed` 接口实现图片的提前加载，由于 `inViewport = resources[i].prerenderAllowed(elementRect, viewportRect) || rect.overlapping(elementRect, viewportRect);` 代码是 `||` 判断，所以应该是无损的。
