### PR TITLE
解决 MIP2 内嵌 MIP1 的问题

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -21,6 +21,8 @@ define(function (require) {
     try {
         if (window.parent.MIP.version === '2') {
             isInMIP2 = true
+        } else {
+            isInMIP2 = false
         }
     } catch (e) {
         isInMIP2 = false

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -67,7 +67,7 @@ define(function (require) {
             }
 
             // Force reload mainly for MIP2
-            window.addEventListener('popstate', e => {
+            window.addEventListener('popstate', function (e) {
                 // 在 SF 情况下 window.top 是跨域的，不操作即可
                 try {
                     window.top.location.reload()

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -136,7 +136,7 @@ define(function (require) {
         sendMessage: function (eventName, data) {
             if (this.isIframed) {
                 // When framed by MIP2, send message to SF (window.top) rather than MIP2 (window.parent)
-                let target = isInMIP2 ? window.top : window.parent
+                var target = isInMIP2 ? window.top : window.parent
                 target.postMessage({
                     event: eventName,
                     data: data

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -68,7 +68,10 @@ define(function (require) {
 
             // Force reload mainly for MIP2
             window.addEventListener('popstate', e => {
-                window.top.location.reload()
+                // 在 SF 情况下 window.top 是跨域的，不操作即可
+                try {
+                    window.top.location.reload()
+                } catch (e) {}
             })
         },
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -115,14 +115,13 @@ define(function (require) {
             this.isShow = true;
             this._showTiming = Date.now();
             this.trigger('show', this._showTiming);
-            try {
-                // Framed by MIP2
-                if (this.isIframed && window.parent.MIP.version === '2') {
-                    window.parent.postMessage({
-                        type: 'load-from-mip1'
-                    }, '*')
-                }
-            } catch (e) {}
+
+            // Framed by MIP2
+            if (this.isIframed && isInMIP2) {
+                window.parent.postMessage({
+                    type: 'load-from-mip1'
+                }, '*')
+            }
         },
 
         /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -19,7 +19,6 @@ define(function (require) {
 
     var isInMIP2
     try {
-        // When framed by MIP2, send message to SF (window.top) rather than MIP2 (window.parent)
         if (window.parent.MIP.version === '2') {
             isInMIP2 = true
         }
@@ -131,6 +130,7 @@ define(function (require) {
          */
         sendMessage: function (eventName, data) {
             if (this.isIframed) {
+                // When framed by MIP2, send message to SF (window.top) rather than MIP2 (window.parent)
                 let target = isInMIP2 ? window.top : window.parent
                 target.postMessage({
                     event: eventName,
@@ -280,15 +280,14 @@ define(function (require) {
                 e.preventDefault();
                 if (this.hasAttribute('mip-link') || this.getAttribute('data-type') === 'mip') {
                     if (self.isIframed && isInMIP2) {
-                        try {
-                            // Framed by standalone MIP2
-                            // MIP2 framed by SF can also be dealt by sendMessage
-                            if (window.parent.MIP.standalone) {
-                                top.location.href = this.href
-                                return
-                            }
-                        } catch (e) {}
+                        // Framed by standalone MIP2
+                        // MIP2 framed by SF can also be dealt by sendMessage
+                        if (window.parent.MIP.standalone) {
+                            top.location.href = this.href
+                            return
+                        }
                     }
+
                     var message = self._getMessageData.call(this);
                     self.sendMessage(message.messageKey, message.messageData);
                 } else {


### PR DESCRIPTION
**提交pr时需要关联issue，请大家遵守**

**1、升级点** （清晰准确的描述升级的功能点）
ISSUE 开在 MIP2 的仓库中，[链接](https://github.com/mipengine/mip2/issues/278)
**2、影响范围** （描述该需求上线会影响什么功能）
使 MIP2 页面能够正常跳转到 MIP1 页面
**3、自测 checklist**
* CASE 1
    * MIP2 页面 A 跳转到 MIP1 页面 B 正常
    * MIP1 页面 B 再次跳转到 MIP1 页面 C1 正常
    * MIP1 页面 B 再次跳转到 MIP2 页面 C2 正常
    * 从 C1 或者 C2 后退能够到达 B
    * 再从 B 后退能退到 A
* CASE 2
    * 直接打开 MIP1 的页面 A
    * 跳转到 MIP1 页面 B1 正常
    * 跳转到 MIP1 页面 B2 正常
    * 从 B1 或者 B2 能够后退到 A

**4、需要覆盖的场景和case**
- [x] 是否覆盖了sf打开mip页
- [ ] 是否验证了极速服务mip页面效果

**5、自测机型和浏览器** 
安卓6.0 自带浏览器 & UC浏览器 & 手百
IPHONE6 (IOS 10) safari & UC 浏览器 & 手百

**6、自测机型和浏览器** 
- [x] 是否覆盖了ios系统手机
- [x] 是否覆盖了安卓系统手机
- [x] 是否覆盖了iphone版式浏览器（比如qq、uc、chrome、safari、安卓自带浏览器）
- [x] 是否覆盖了手百
